### PR TITLE
feat(ci): add trunk-format workflow

### DIFF
--- a/.github/workflows/trunk-format.yml
+++ b/.github/workflows/trunk-format.yml
@@ -1,0 +1,47 @@
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+    tags-ignore: ["v[0-9]+.[0-9]+.[0-9]+*"]
+    paths:
+      - "**.ts"
+      - "**.tsx"
+      - "**.js"
+      - "**.mjs"
+      - "**.cs"
+      - ".github/workflows/**.yml"
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          version: latest
+
+      - name: Run Biome Format
+        run: biome format --write .
+
+      - name: Commit changes
+        if: success()
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: format with biome"
+          file_pattern: "**/*.{js,jsx,ts,tsx,mjs}"
+          status_options: "--untracked-files=no"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
- Added a new GitHub Actions workflow for code formatting
- The workflow triggers on push to the main branch and ignores version tags